### PR TITLE
fix(helpers): searchItems() type sig compatibility

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -335,7 +335,7 @@ export function defaultFilter (value: any, search: string | null, item: any) {
     value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1
 }
 
-export function searchItems<T extends any = any> (items: T[], search: string): T[] {
+export function searchItems<T extends object = object> (items: T[], search: string): T[] {
   if (!search) return items
   search = search.toString().toLowerCase()
   if (search.trim() === '') return items


### PR DESCRIPTION
## Description

TypeScript complains and fails (on my system) with `error TS2769: No overload matches this call` when running `yarn build lib`. The search algorithm in [the `searchItems()` function](https://github.com/vuetifyjs/vuetify/blob/dev/packages/vuetify/src/util/helpers.ts#L338) uses `Object.keys(item)` to filter the list of items, which will _only_ succeed with objects. Since the function is designed to filter objects, it seems reasonable that the type signature reflects this.

Current signature: 

```ts
export function searchItems<T extends any = any> (items: T[], search: string): T[] {}
```

Suggested signature: 

```ts
export function searchItems<T extends object = object> (items: T[], search: string): T[] {}
```

## Motivation and Context

This type signature was introduced in b03b507 (2019-12-02). It affects `es5/lib` builds for packages that extend Vuetify.

## How Has This Been Tested?

Ran `yarn build lib`. There was no error and libs were built as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) N/A
